### PR TITLE
Use SRI hash for Cookie Banner

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -96,8 +96,8 @@
 		</script>
 
 		<!-- GDPR-compliant Open Source Cookie Banner (on GitHub by dobarkod/cookie-banner) -->
-		<script type="text/javascript" id="cookiebanner" src="https://cdnjs.cloudflare.com/ajax/libs/cookie-banner/1.2.2/cookiebanner.min.js"></script>
-		
+		<script type="text/javascript" id="cookiebanner" src="https://cdnjs.cloudflare.com/ajax/libs/cookie-banner/1.2.2/cookiebanner.min.js" integrity="sha256-yMTd5YyqT/43FMnYHf9OAEsz7SKMIBhxQTO9MvWN6kQ=" crossorigin="anonymous"></script>
+
 		<!-- Google Tag Manager -->
 		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
SRI is a new W3C specification (https://www.w3.org/TR/SRI/) that allows web developers to ensure that resources hosted on third-party servers have not been tampered with. Use of SRI is recommended as a best-practice, whenever libraries are loaded from a third-party source.

When the request is not on the same origin the crossorigin attribute must be present to check the integrity of the file. Without a crossorigin attribute, the browser will choose to 'fail-open' which means it will load the resource as if the integrity attribute was not set, effectively losing all the security SRI brings in the first place.

'crossorigin="anonymous"' results that no credentials are sent to the cross-origin site hosting the content. However, it will send an Origin HTTP header. If the server denies including the resource (by not setting the Access-Control-Allow-Origin HTTP header), the resource will not be used by the browser.

Why SHA-256? From a security perspective, SHA-256 is just as secure as SHA-384 or SHA-512. We can't produce collisions in any of them with current or foreseeable technology, so the security you get is identical.

From a non-security perspective, the reasons to choose SHA-256 over the longer digests are more easily apparent: it's smaller, requiring less bandwidth to store and transmit, less memory and in many cases less processing power to compute. (There are cases where SHA-512 is faster and more efficient.) 

Generated SRI hash with at www.srihash.org.