### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse-check.yml
+++ b/.github/workflows/lighthouse-check.yml
@@ -1,5 +1,7 @@
 name: Lighthouse
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   lighthouse:


### PR DESCRIPTION
Potential fix for [https://github.com/elara-aerospace/elara-aerospace.github.io/security/code-scanning/16](https://github.com/elara-aerospace/elara-aerospace.github.io/security/code-scanning/16)

To resolve the issue, we will add an explicit `permissions` block at the workflow level to define minimum permissions required for the job. Since the workflow appears to involve checking out code and running a Lighthouse check, the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access to the repository content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add contents: read permission at the workflow level in .github/workflows/lighthouse-check.yml