### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Codecov Workflow for elara-aerospace.com
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   run:


### PR DESCRIPTION
Potential fix for [https://github.com/elara-aerospace/elara-aerospace.github.io/security/code-scanning/17](https://github.com/elara-aerospace/elara-aerospace.github.io/security/code-scanning/17)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. The best way is to add the block at the workflow root (above `jobs:`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is likely `contents: read`, as the steps only check out code, set up Ruby, install dependencies, and upload coverage (none of which require write access to the repository). The change should be made at the top of `.github/workflows/ci.yml`, after the `name:` and before `on:` or `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Restrict GITHUB_TOKEN permissions to contents: read in .github/workflows/ci.yml